### PR TITLE
SL-52152_Desenvolver-SL-52142-Importao-arquivo-retorno-do-Sicredi-se-o-recebimento-inclui-juros-e-multa-o-ttulo-no--baixado-no-MXP

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Sicredi.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicredi.cs
@@ -640,7 +640,7 @@ namespace BoletoNet
         {
             bool vRetorno = true;
             string vMsg = string.Empty;
-            //            
+            //
             switch (tipoArquivo)
             {
                 case TipoArquivo.CNAB240:
@@ -706,7 +706,7 @@ namespace BoletoNet
                     }
                     else if (String.IsNullOrEmpty(boleto.Remessa.TipoDocumento))
                     {
-                        // Para o Sicredi, defini o Tipo de Documento sendo: 
+                        // Para o Sicredi, defini o Tipo de Documento sendo:
                         //       A = 'A' - SICREDI com Registro
                         //      C1 = 'C' - SICREDI sem Registro Impressão Completa pelo Sicredi
                         //      C2 = 'C' - SICREDI sem Registro Pedido de bloquetos pré-impressos
@@ -896,7 +896,7 @@ namespace BoletoNet
                 }
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0157, 002, 0, vInstrucao1, '0'));                               //157-158
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0159, 002, 0, vInstrucao2, '0'));                               //159-160
-                #endregion               
+                #endregion
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0161, 013, 2, ValorOuPercJuros, '0'));                          //161-173 Valor/% de juros por dia de atraso
                 #region DataDesconto
                 string vDataDesconto = "000000";
@@ -1203,6 +1203,9 @@ namespace BoletoNet
                 //Juros Mora
                 decimal jurosMora = Convert.ToUInt64(reg.JurosMora);
                 detalhe.JurosMora = jurosMora / 100;
+                //Multa
+                decimal valorMulta = Convert.ToDecimal(reg.Multa);
+                detalhe.ValorMulta = valorMulta / 100;
                 //Filler7
                 //SomenteOcorrencia19
                 //Filler8

--- a/src/Boleto.Net/Boleto.Net.csproj
+++ b/src/Boleto.Net/Boleto.Net.csproj
@@ -370,6 +370,12 @@
     <EmbeddedResource Include="Imagens\084.jpg" />
     <Content Include="Imagens\097.jpg" />
   </ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.3">
+		<PrivateAssets>all</PrivateAssets>
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -378,7 +384,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
- Desenvolver-SL-52142 - Adicionar assembly reference para .netFramework 4.0
- Desenvolver-SL-52142 - Adicionar leitura do valor da multa no detalhe retorno Sicredi
